### PR TITLE
Implement CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+env:
+  DOTNET_VERSION: "6.0.x"
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: build and test
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+
+      - name: setup dotnet
+        uses: actions/setup-dotnet@v2
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: dotnet build
+        run: dotnet build
+
+      - name: dotnet test
+        run: dotnet test --no-build --no-restore --logger "junit;LogFilePath=unit-tests.xml"
+
+      - name: publish test results
+        uses: EnricoMi/publish-unit-test-result-action@v1
+        if: always()
+        with:
+          files: "**/*-tests.xml"
+          check_name: "Unit Test Results"

--- a/SystemTextJsonPatch.Tests/SystemTextJsonPatch.Tests.csproj
+++ b/SystemTextJsonPatch.Tests/SystemTextJsonPatch.Tests.csproj
@@ -18,6 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="JUnitTestLogger" Version="1.1.0" />
     <PackageReference Include="Microsoft.Net.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="Moq" Version="4.18.1" />
     <PackageReference Include="xunit" Version="2.4.1" />


### PR DESCRIPTION
Fixes #2 

On top of regular build & test, I've added support for publishing test result in a message to the PR, see example [here](https://github.com/ilmax/SystemTextJsonPatch/runs/6550635899?check_suite_focus=true) and [here](https://github.com/ilmax/SystemTextJsonPatch/pull/1#issuecomment-1134271466)
This part is optional and can be removed if you don't like it

The inspiration for this was from github valet, see [here](https://github.com/github/gh-valet)