### PR TITLE
Serialize operation value directly into json writer

### DIFF
--- a/SystemTextJsonPatch/Converters/JsonPatchDocumentConverterBase.cs
+++ b/SystemTextJsonPatch/Converters/JsonPatchDocumentConverterBase.cs
@@ -113,9 +113,8 @@ namespace SystemTextJsonPatch.Converters
                         writer.WriteString("from", operation.from);
                     }
 
-                    var json = JsonSerializer.Serialize(operation.value, options);
                     writer.WritePropertyName("value");
-                    writer.WriteRawValue(json);
+                    JsonSerializer.Serialize(writer, operation.value, options);
                     writer.WriteEndObject();
                 }
 


### PR DESCRIPTION
Avoids a string allocation and is faster.