### PR TITLE
Fix issue when adding a new complex value to a generic dictionary

### DIFF
--- a/SystemTextJsonPatch.Tests/IntegrationTests/DictionaryIntegrationTest.cs
+++ b/SystemTextJsonPatch.Tests/IntegrationTests/DictionaryIntegrationTest.cs
@@ -169,6 +169,32 @@ public class DictionaryTest
 	}
 
 	[Fact]
+	public void AddPocoObjectSucceeds()
+	{
+		// Arrange
+		var key1 = 100;
+		var value1 = new Customer() { Name = "James" };
+		var key2 = 200;
+		var value2 = new Customer() { Name = "Mike" };
+		var model = new CustomerDictionary();
+		model.DictionaryOfStringToCustomer[key1] = value1;
+		var patchDocument = new JsonPatchDocument();
+		patchDocument.Add($"/DictionaryOfStringToCustomer/{key2}", value2);
+
+		// Act
+		patchDocument.ApplyTo(model);
+
+		// Assert
+		Assert.Equal(2, model.DictionaryOfStringToCustomer.Count);
+		var actualValue1 = model.DictionaryOfStringToCustomer[key1];
+		Assert.NotNull(actualValue1);
+		Assert.Equal("James", actualValue1.Name);
+		var actualValue2 = model.DictionaryOfStringToCustomer[key2];
+		Assert.NotNull(actualValue2);
+		Assert.Equal("Mike", actualValue2.Name);
+	}
+
+	[Fact]
 	public void AddReplacesPocoObjectSucceeds()
 	{
 		// Arrange

--- a/SystemTextJsonPatch.Tests/IntegrationTests/DictionaryIntegrationTest.cs
+++ b/SystemTextJsonPatch.Tests/IntegrationTests/DictionaryIntegrationTest.cs
@@ -1,4 +1,6 @@
 ﻿using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
 using SystemTextJsonPatch.Exceptions;
 using Xunit;
 
@@ -135,6 +137,27 @@ public class DictionaryTest
 		public IDictionary<int, Customer> DictionaryOfStringToCustomer { get; } = new Dictionary<int, Customer>();
 	}
 
+#if NET7_0_OR_GREATER
+	[JsonDerivedType(typeof(Dog), "dog")]
+	[JsonDerivedType(typeof(Cat), "cat")]
+	private abstract class Animal
+	{
+	}
+
+	private class Dog : Animal
+	{
+	}
+
+	private class Cat : Animal
+	{
+	}
+
+	private class AnimalDictionary
+	{
+		public IDictionary<int, Animal> DictionaryOfIntToAnimal { get; } = new Dictionary<int, Animal>();
+	}
+#endif
+
 	[Fact]
 	public void TestPocoObjectSucceeds()
 	{
@@ -217,6 +240,27 @@ public class DictionaryTest
 		Assert.NotNull(actualValue1);
 		Assert.Equal("James", actualValue1.Name);
 	}
+
+#if NET7_0_OR_GREATER
+	[Fact]
+	public void AddReplacesPocoObjectWithDifferentTypeSucceeds()
+	{
+		// Arrange
+		var key1 = 100;
+		var value1 = new Cat();
+		var model = new AnimalDictionary();
+		model.DictionaryOfIntToAnimal[key1] = value1;
+		var patchDocument = new JsonPatchDocument();
+		patchDocument.Add($"/DictionaryOfIntToAnimal/{key1}", new Dog());
+
+		// Act
+		patchDocument.ApplyTo(model);
+
+		// Assert
+		var actualValue1 = Assert.Single(model.DictionaryOfIntToAnimal).Value;
+		Assert.IsType<Dog>(actualValue1);
+	}
+#endif
 
 	[Fact]
 	public void RemovePocoObjectSucceeds()

--- a/SystemTextJsonPatch/Internal/PocoAdapter.cs
+++ b/SystemTextJsonPatch/Internal/PocoAdapter.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Dynamic;
 using System.Linq;
+using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using SystemTextJsonPatch.Internal.Proxies;
@@ -200,7 +201,12 @@ public sealed class PocoAdapter : IAdapter
 			{
 				var key = converter.ConvertFromInvariantString(propertyName);
 				var proxyType = typeof(DictionaryTypedPropertyProxy<,>).MakeGenericType(keyType, valueType);
-				return (IPropertyProxy)Activator.CreateInstance(proxyType, target, key)!;
+				return (IPropertyProxy)Activator.CreateInstance(
+					proxyType,
+					BindingFlags.NonPublic | BindingFlags.Instance,
+					null,
+					[target, key],
+					null)!;
 			}
 		}
 

--- a/SystemTextJsonPatch/Internal/Proxies/DictionaryTypedPropertyProxy.cs
+++ b/SystemTextJsonPatch/Internal/Proxies/DictionaryTypedPropertyProxy.cs
@@ -8,7 +8,7 @@ namespace SystemTextJsonPatch.Internal.Proxies
 		private readonly IDictionary<TKey, TValue?> _dictionary;
 		private readonly TKey _propertyName;
 
-		public DictionaryTypedPropertyProxy(IDictionary<TKey, TValue?> dictionary, TKey propertyName)
+		internal DictionaryTypedPropertyProxy(IDictionary<TKey, TValue?> dictionary, TKey propertyName)
 		{
 			_dictionary = dictionary;
 			_propertyName = propertyName;

--- a/SystemTextJsonPatch/Internal/Proxies/DictionaryTypedPropertyProxy.cs
+++ b/SystemTextJsonPatch/Internal/Proxies/DictionaryTypedPropertyProxy.cs
@@ -3,12 +3,12 @@ using System.Collections.Generic;
 
 namespace SystemTextJsonPatch.Internal.Proxies
 {
-	internal sealed class DictionaryTypedPropertyProxy : IPropertyProxy
+	internal sealed class DictionaryTypedPropertyProxy<TKey, TValue> : IPropertyProxy
 	{
-		private readonly IDictionary<string, object?> _dictionary;
-		private readonly string _propertyName;
+		private readonly IDictionary<TKey, TValue?> _dictionary;
+		private readonly TKey _propertyName;
 
-		internal DictionaryTypedPropertyProxy(IDictionary<string, object?> dictionary, string propertyName)
+		public DictionaryTypedPropertyProxy(IDictionary<TKey, TValue?> dictionary, TKey propertyName)
 		{
 			_dictionary = dictionary;
 			_propertyName = propertyName;
@@ -25,11 +25,11 @@ namespace SystemTextJsonPatch.Internal.Proxies
 		{
 			if (_dictionary.ContainsKey(_propertyName))
 			{
-				_dictionary[_propertyName] = convertedValue;
+				_dictionary[_propertyName] = (TValue?)convertedValue;
 			}
 			else
 			{
-				_dictionary.Add(_propertyName, convertedValue);
+				_dictionary.Add(_propertyName, (TValue?)convertedValue);
 			}
 		}
 
@@ -48,7 +48,7 @@ namespace SystemTextJsonPatch.Internal.Proxies
 				_dictionary.TryGetValue(_propertyName, out var val);
 				if (val == null)
 				{
-					return typeof(object);
+					return typeof(TValue);
 				}
 
 				return val.GetType();

--- a/SystemTextJsonPatch/Internal/Proxies/DictionaryTypedPropertyProxy.cs
+++ b/SystemTextJsonPatch/Internal/Proxies/DictionaryTypedPropertyProxy.cs
@@ -41,18 +41,6 @@ namespace SystemTextJsonPatch.Internal.Proxies
 		public bool CanRead => true;
 		public bool CanWrite => true;
 
-		public Type PropertyType
-		{
-			get
-			{
-				_dictionary.TryGetValue(_propertyName, out var val);
-				if (val == null)
-				{
-					return typeof(TValue);
-				}
-
-				return val.GetType();
-			}
-		}
+		public Type PropertyType => typeof(TValue);
 	}
 }


### PR DESCRIPTION
This pr fixes an issue that it shown by the added test where it is not possible to add a complex object to a typed dictionary.

The fix prefers to use the `IDictionary<TKey, TValue>` proxy over the `IDictionary` proxy as e.g. `Dictionary<TKey, TValue>` implements both.