### PR TITLE
Add snake case test

### DIFF
--- a/SystemTextJsonPatch.Tests/IntegrationTests/NestedObjectIntegrationTest.cs
+++ b/SystemTextJsonPatch.Tests/IntegrationTests/NestedObjectIntegrationTest.cs
@@ -2,6 +2,7 @@ using System;
 using System.Dynamic;
 using System.Text.Json;
 using SystemTextJsonPatch.Exceptions;
+using SystemTextJsonPatch.Operations;
 using Xunit;
 
 namespace SystemTextJsonPatch.IntegrationTests;
@@ -56,6 +57,39 @@ public class NestedObjectIntegrationTest
 		// Assert
 		Assert.Equal("B", targetObject.NestedObject.StringProperty);
 	}
+	
+#if NET8_0
+	
+	[Fact]
+	public void ReplaceNestedObjectWithPlainStrings()
+	{
+		// Arrange
+		var targetObject = new SimpleObjectWithNestedObject()
+		{
+			IntegerValue = 1,
+			NestedObject = null
+		};
+		var options = new JsonSerializerOptions()
+		{
+			PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower
+		};
+
+		var newNested = new NestedObject { StringProperty = "B" };
+		var patchDocument = new JsonPatchDocument<SimpleObjectWithNestedObject>();
+		patchDocument.Operations.Add(new Operation<SimpleObjectWithNestedObject>("replace", "/nested_object", JsonSerializer.Serialize(newNested, options)));
+		patchDocument.Options = options;
+
+		var serialized = JsonSerializer.Serialize(patchDocument, options);
+		var deserialized = JsonSerializer.Deserialize<JsonPatchDocument<SimpleObjectWithNestedObject>>(serialized, options);
+
+		// Act
+		deserialized.ApplyTo(targetObject);
+
+		// Assert
+		Assert.Equal("B", targetObject.NestedObject.StringProperty);
+	}
+	
+#endif
 
 	[Fact]
 	public void TestStringPropertyInNestedObject()


### PR DESCRIPTION
Here is the test describing true snake case approach using for both `path` and nested object `value` values.

`{op:"replace", path:"/nested_property", value:"{first_prop:1, second_prop:2}"}`

PocoAdapter using snake case handling tries to convert `snake_case_name` to snake case again and then fails to find the property.
![image](https://github.com/user-attachments/assets/ce1b64b3-1979-40a4-984e-9261947caa80)

NET8 has no explicit PascalCase naming policy which is default (null). The condition above returns just a name which is `sanka_case_name` as it was passed and then fails to find the property.

I have tried to create PascalCase naming policy myself. It works for path and we can find the target property but it leads to fail during value application which is snake_case as well.

Test works for case when path has PascalCase and value has snake_case though:
`{op:"replace", path:"/NestedProperty", value:"{first_prop:1, second_prop:2}"}`

We have truly snake_case API where client uses snake_case for both path and value. And it works with Newtonsoft. What is the best way to make it work with SystemText? 
